### PR TITLE
Disable bunnyhop cap

### DIFF
--- a/pm_shared/pm_shared.cpp
+++ b/pm_shared/pm_shared.cpp
@@ -2556,7 +2556,7 @@ void PM_Jump (void)
 	// In the air now.
     pmove->onground = -1;
 
-	PM_PreventMegaBunnyJumping();
+	// PM_PreventMegaBunnyJumping();
 
 	if ( tfc )
 	{

--- a/pm_shared/pm_shared.cpp
+++ b/pm_shared/pm_shared.cpp
@@ -2439,7 +2439,7 @@ void PM_NoClip()
 //  running PM_AirMove, which doesn't crop velocity to maxspeed like the ground / other
 //  movement logic does.
 //-----------------------------------------------------------------------------
-/* void PM_PreventMegaBunnyJumping( void )
+void PM_PreventMegaBunnyJumping( void )
 {
 	// Current player speed
 	float spd;
@@ -2463,7 +2463,6 @@ void PM_NoClip()
 	
 	VectorScale( pmove->velocity, fraction, pmove->velocity ); //Crop it down!.
 }
-*/
 
 /*
 =============

--- a/pm_shared/pm_shared.cpp
+++ b/pm_shared/pm_shared.cpp
@@ -2439,7 +2439,7 @@ void PM_NoClip()
 //  running PM_AirMove, which doesn't crop velocity to maxspeed like the ground / other
 //  movement logic does.
 //-----------------------------------------------------------------------------
-void PM_PreventMegaBunnyJumping( void )
+/* void PM_PreventMegaBunnyJumping( void )
 {
 	// Current player speed
 	float spd;
@@ -2463,6 +2463,7 @@ void PM_PreventMegaBunnyJumping( void )
 	
 	VectorScale( pmove->velocity, fraction, pmove->velocity ); //Crop it down!.
 }
+*/
 
 /*
 =============


### PR DESCRIPTION
This reverts a change made in an early post-release version of HL1 where players touching the ground with >=550ups horizontal velocity have their speed reduced, aimed at preventing bunnyhopping from exceeding the above mentioned speed. 

I've commented it out instead of removing it to allow people to re-enable it for their mod depending on their preferences, but I feel ADM should ship with it disabled as a default. Regular players would almost never encounter it, as it requires a frame perfect `+jump`  input to conserve any momentum, and it only serves to prevent a _very_ small minority of players, namely speedrunners, from gaining extra enjoyment out of a mod. 